### PR TITLE
html_include.awk getting TEMPLATE_DIR

### DIFF
--- a/html_include.awk
+++ b/html_include.awk
@@ -6,6 +6,13 @@ BEGIN {
 
 /<!--include/ {
     file = $2
+
+    # Need to set TEMPLATE_DIR in ENV
+    template_path = ENVIRON["TEMPLATE_DIR"]
+    if (template_path != "") {
+        file = template_path "/" $2
+    }
+
     while((getline < file ) > 0 ) {
     	print $0
     }


### PR DESCRIPTION
Getting the TEMPLATE_DIR first, if TEMPLATE_DIR not set in ENV, it would find templates in root directory.